### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     bindata (2.0.0)
     configatron (3.1.3)
-    lifx (0.4.6)
+    lifx (0.4.11)
       bindata (~> 2.0)
       configatron (~> 3.0)
       timers (~> 1.0)


### PR DESCRIPTION
lifx 0.4.6 has been yanked from RubyGems repository, updating to 0.4.11 (latest)
